### PR TITLE
Absolute paths, open browser on Linux and no browser prefix first

### DIFF
--- a/gradify.py
+++ b/gradify.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-import sys, os, argparse
+import sys, os, argparse, platform
 from PIL import Image, ImageFilter
 
 """ Image Gradients
@@ -14,6 +14,12 @@ class Gradify():
   
   # Cross browser prefixes.
   BROWSER_PREFIXES = ["", "-webkit-", "-moz-", "-o-", "-ms-"]
+
+  # Demo browser execution
+  DEMO_CMD = {
+    'Linux': 'xdg-open %s',
+    'Windows': 'start %s' # Not tested (http://superuser.com/questions/246825/open-file-from-the-command-line-on-windows)
+  }
 
   def __init__(self, black_sensitivity=4.3, white_sensitivity = 3, num_colors=4, resize=55, uniformness=7, webkit_only=False):
 
@@ -54,8 +60,11 @@ class Gradify():
     if not self.args.file:
       self.get_dir("")
     if self.args.demo:
-      # TODO: Sorry windows, will fix later
-      os.system("open " + self.demo_file)
+      platformName = platform.system()
+      if platformName in self.DEMO_CMD:
+        os.system(self.DEMO_CMD[platformName] % self.demo_file)
+      else: # Fallback
+        os.system("open " + self.demo_file)
     else:
       self.printRules()
 

--- a/gradify.py
+++ b/gradify.py
@@ -183,14 +183,12 @@ class Gradify():
       print("}")
 
   def get_file(self, filen):
-    if not "./" is filen[0:1]:
-      filen = "./" + filen
     self.image = Image.open(filen)
     self.imageFileName = filen
     self.get_directions(filen)
 
   def get_dir(self, dir):
-    dir = "./"+ dir + "/"
+    dir = dir + "/"
     self.num_files = len(os.listdir(dir))
     for fn in os.listdir(dir):
       fn = dir + fn

--- a/gradify.py
+++ b/gradify.py
@@ -13,7 +13,7 @@ class Gradify():
   """
   
   # Cross browser prefixes.
-  BROWSER_PREFIXES = ["-webkit-","", "-moz-", "-o-", "-ms-"]
+  BROWSER_PREFIXES = ["", "-webkit-", "-moz-", "-o-", "-ms-"]
 
   def __init__(self, black_sensitivity=4.3, white_sensitivity = 3, num_colors=4, resize=55, uniformness=7, webkit_only=False):
 


### PR DESCRIPTION
Browser doesn't render correctly without commit 599292c on my machine (Debian 8 32Bit). Tested on Firefox nightly, Chromium and Midori.
