### PR TITLE
Remove extra line feeds: grad.py

### DIFF
--- a/gradify.py
+++ b/gradify.py
@@ -174,16 +174,16 @@ class Gradify():
         print(".%s-%d {" % (self.args.classname, pair[0]))
       else:
         print(".gradify-%d {" % (pair[0]))
-      print("background:")
+      sys.stdout.write("background: ")
       if self.args.single:
         print "rgb(" + str(pair[1][0])+"," + str(pair[1][1]) +"," + str(pair[1][2]) +");"
       else:
         print "rgb(" + str(pair[1][0][0])+"," + str(pair[1][0][1]) +"," + str(pair[1][0][2]) +");"
       if not self.args.single:
-        print("background:")
+        sys.stdout.write("background: ")
         for prefix in self.BROWSER_PREFIXES:
           for color in pair[1]:
-            print prefix + "linear-gradient("+str(color[3])+"deg, rgba(" + str(color[0])+"," + str(color[1]) +"," + str(color[2]) +","+str(1)+") 0%, rgba(" + str(color[0])+"," + str(color[1]) +"," + str(color[2]) +",0) 100%)"
+            sys.stdout.write(prefix + "linear-gradient("+str(color[3])+"deg, rgba(" + str(color[0])+"," + str(color[1]) +"," + str(color[2]) +","+str(1)+") 0%, rgba(" + str(color[0])+"," + str(color[1]) +"," + str(color[2]) +",0) 100%)")
             i += 1
             if i==self.MAX_COLORS:
               print ";"


### PR DESCRIPTION
Followed is bad:

``` css
background:
rgb(249,244,238);
background:
-webkit-linear-gradient(180deg, rgba(249,244,238,1) 0%, rgba(249,244,238,0) 100%)
,
```

This is better:

``` css
background: rgb(249,244,238);
background: -webkit-linear-gradient(180deg, rgba(249,244,238,1) 0%, rgba(249,244,238,0) 100%),
```
